### PR TITLE
Extract a class to make possible to install apple-gcc42

### DIFF
--- a/manifests/gcc_42.pp
+++ b/manifests/gcc_42.pp
@@ -1,0 +1,24 @@
+# Public: Install apple-gcc42 via homebrew
+#
+# Examples
+#
+#   include gcc::gcc_42
+class gcc::gcc_42 {
+  case $::operatingsystem {
+    'Darwin': {
+      include homebrew
+
+      homebrew::formula { 'apple-gcc42':
+        before => Package['boxen/brews/apple-gcc42'],
+      }
+
+      package { 'boxen/brews/apple-gcc42':
+        ensure => '4.2.1-5666.3-boxen1'
+      }
+    }
+
+    default: {
+      # noop
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,13 +11,7 @@ class gcc {
 
       case $::macosx_productversion_major {
         '10.8': {
-          homebrew::formula { 'apple-gcc42':
-            before => Package['boxen/brews/apple-gcc42'],
-          }
-
-          package { 'boxen/brews/apple-gcc42':
-            ensure => '4.2.1-5666.3-boxen1'
-          }
+          require gcc::gcc_42
         }
 
         '10.9': {

--- a/spec/classes/gcc__gcc_42_spec.rb
+++ b/spec/classes/gcc__gcc_42_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'gcc::gcc_42' do
+  let(:facts) { default_test_facts }
+
+  it do
+    should contain_homebrew__formula('apple-gcc42').
+      with_before('Package[boxen/brews/apple-gcc42]')
+
+    should contain_package('boxen/brews/apple-gcc42').with({
+      :ensure => '4.2.1-5666.3-boxen1'
+    })
+  end
+end

--- a/spec/classes/gcc_spec.rb
+++ b/spec/classes/gcc_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe 'gcc' do
-  let(:facts) { default_test_facts }
+  let(:facts) { default_test_facts.merge(:macosx_productversion_major => 10.9) }
 
   it do
-    should contain_homebrew__formula('apple-gcc42').
-      with_before('Package[boxen/brews/apple-gcc42]')
+    should contain_homebrew__tap('homebrew/versions').
+      with_ensure('present')
 
-    should contain_package('boxen/brews/apple-gcc42').with({
-      :ensure => '4.2.1-5666.3-boxen1'
+    should contain_package('homebrew/versions/gcc48').with({
+      :require => 'Homebrew::Tap[homebrew/versions]'
     })
   end
 end


### PR DESCRIPTION
Even on Mavericks apple-gcc42 is require to install Ruby Enterprise Edition
