### PR TITLE
Update GCC48 version to 4.8.3 and add boxen prefix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class gcc {
           homebrew::formula { 'gcc48': }
 
           package { 'boxen/brews/gcc48':
-            ensure => '4.8.1',
+            ensure => '4.8.3-boxen1',
           }
         }
 

--- a/spec/classes/gcc_spec.rb
+++ b/spec/classes/gcc_spec.rb
@@ -4,6 +4,8 @@ describe 'gcc' do
   let(:facts) { default_test_facts.merge(:macosx_productversion_major => 10.9) }
 
   it do
-    should contain_package('boxen/brews/gcc48')
+    should contain_package('boxen/brews/gcc48').with({
+      :ensure => '4.8.3-boxen1'
+    })
   end
 end


### PR DESCRIPTION
I saw @wfarr [removed the boxen prefix when he vendored the homebrew recipe](https://github.com/boxen/puppet-gcc/commit/85e1dade615b79f2de6d4997b9a8a0d06be6438b) but I believe it is better to follow the pattern we are using to vendored recipes in all the modules.

BTW, I think we can safely remove the `sighs` branch now that I merged it on master.

cc @dgoodlad @tarebyte 
