### PR TITLE
Use gcc48 on all platforms.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,32 +14,16 @@ class gcc {
           include gcc::apple_gcc42
         }
 
-        '10.9': {
-          ensure_resource('homebrew::tap',
-            'homebrew/versions', { 'ensure' => 'present' })
-
-          homebrew::formula { 'gcc48': }
-
-          package { 'boxen/brews/gcc48':
-            ensure  => '4.8.3-boxen2',
-            require => Homebrew::Tap['homebrew/versions']
-          }
-        }
-
-        '10.10': {
-          ensure_resource('homebrew::tap',
-            'homebrew/versions', { 'ensure' => 'present' })
-
-          homebrew::formula { 'gcc48': }
-
-          package { 'boxen/brews/gcc48':
-            ensure  => '4.8.3-boxen2',
-            require => Homebrew::Tap['homebrew/versions']
-          }
-        }
-
         default: {
-          # noop
+          ensure_resource('homebrew::tap',
+            'homebrew/versions', { 'ensure' => 'present' })
+
+          homebrew::formula { 'gcc48': }
+
+          package { 'boxen/brews/gcc48':
+            ensure  => '4.8.3-boxen2',
+            require => Homebrew::Tap['homebrew/versions']
+          }
         }
       }
     }


### PR DESCRIPTION
This fix is primarily for El Capitan (10.11) but it also makes sense to just make this the default rather than a no-op.