### PR TITLE
Add El Capitan GCC 5 patch.

### DIFF
--- a/files/brews/gcc5.rb
+++ b/files/brews/gcc5.rb
@@ -32,6 +32,15 @@ class Gcc5 < Formula
     sha256 "5cc7eaaab1dd29879109ccf896f91c691ba6267a997288ee526e3f21479a8f02" => :mountain_lion
   end
 
+  if MacOS.version >= :el_capitan
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
   # GCC's Go compiler is not currently supported on Mac OS X.
   # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
   option "with-fortran", "Build the gfortran compiler"


### PR DESCRIPTION
Fixes the build of GCC on El Capitan (OS X 10.11).