### PR TITLE
Patch gcc for xcode 7 if xcode version is >= 7.0

### DIFF
--- a/files/brews/gcc5.rb
+++ b/files/brews/gcc5.rb
@@ -32,7 +32,7 @@ class Gcc5 < Formula
     sha256 "5cc7eaaab1dd29879109ccf896f91c691ba6267a997288ee526e3f21479a8f02" => :mountain_lion
   end
 
-  if MacOS.version >= :el_capitan
+  if MacOS::Xcode.version >= "7.0"
     # Fixes build with Xcode 7.
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
     patch do


### PR DESCRIPTION
The existing code does this if running el capitan - so this fails with xcode 7.x if you're running that on yosemite (I tested with up to date yosemite, and xcode 7.1). GCC bootstrap fails without this in that environment.
