### PR TITLE
This should resolve the updating problems for older gcc's

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,14 +18,15 @@ class gcc {
         ensure  => '5.1.0',
         require => Homebrew::Tap['homebrew/versions']
       }
+
+      package { ['boxen/brews/apple-gcc42', 'boxen/brews/gcc48']:
+        ensure => 'absent'
+      }
     }
 
     default: {
       package { 'gcc': }
 
-      package { ['boxen/brews/apple-gcc42', 'boxen/brews/gcc48']:
-        ensure => 'absent'
-      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,10 @@ class gcc {
 
     default: {
       package { 'gcc': }
+
+      package { ['apple-gcc42', 'gcc48']:
+        ensure => 'absent'
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class gcc {
     default: {
       package { 'gcc': }
 
-      package { ['apple-gcc42', 'gcc48']:
+      package { ['boxen/brews/apple-gcc42', 'boxen/brews/gcc48']:
         ensure => 'absent'
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,6 @@ class gcc {
 
     default: {
       package { 'gcc': }
-
     }
   }
 

--- a/spec/classes/gcc_spec.rb
+++ b/spec/classes/gcc_spec.rb
@@ -13,11 +13,11 @@ describe 'gcc' do
     })
 
     should contain_package('boxen/brews/apple-gcc42').with({
-        :ensure => 'absent'
+      :ensure => 'absent'
     })
 
     should contain_package('boxen/brews/gcc48').with({
-        :ensure => 'absent'
+      :ensure => 'absent'
     })
   end
 end

--- a/spec/classes/gcc_spec.rb
+++ b/spec/classes/gcc_spec.rb
@@ -11,5 +11,13 @@ describe 'gcc' do
       :ensure => '5.1.0',
       :require => 'Homebrew::Tap[homebrew/versions]'
     })
+
+    should contain_package('boxen/brews/apple-gcc42').with({
+        :ensure => 'absent'
+    })
+
+    should contain_package('boxen/brews/gcc48').with({
+        :ensure => 'absent'
+    })
   end
 end


### PR DESCRIPTION
Resolves the issue mentioned in https://github.com/boxen/puppet-homebrew/issues/98

I *think* I did the spec tests correctly, but I wasn't able to execute them on my mac, got ruby "frozen symbol" errors.

```
./script/specs 
gitwork/puppet-gcc/.bundle/ruby/2.1.0/gems/puppet-3.2.2/lib/puppet/util/autoload.rb:68:in `rescue in load_file': Could not autoload puppet/type/component: can't modify frozen Symbol (Puppet::Error)
```

Hopefully travis passes and I intuited the specs correctly.