### PR TITLE
remove deprecated `fails_with :llvm` directive

### DIFF
--- a/files/brews/gcc5.rb
+++ b/files/brews/gcc5.rb
@@ -64,8 +64,6 @@ class Gcc5 < Formula
     depends_on "cctools" => :build
   end
 
-  fails_with :llvm
-
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   def pour_bottle?


### PR DESCRIPTION
see deprecation warning at https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula.rb#L2372